### PR TITLE
FAT module update for UStealth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ NO ONE BUT YOURSELF IS RESPONSIBLE FOR ANY DAMAGE TO YOUR WII CONSOLE BECAUSE OF
  * *Oggzee*, for his brilliant fraglist.
  * *WiiPower*, for the great help with ios reload block from usb.
  * *dragbe* and *NutNut*, for their [d2x cios installer](http://code.google.com/p/d2x-cios-installer).
- * *XFlak*, for his wonderful [ModMii](http://gbatemp.net/topic/207126-modmii-for-windows) which supported d2x wads since its birth. Without ModMii d2x cios would probably never have existed. Also, XFlak had the original idea to replace the buggy EHCI module of cIOSX rev21 with the  working one from rev19. 
+ * *XFlak*, for his wonderful [ModMii](https://gbatemp.net/threads/best-way-to-mod-any-wii-modmii-for-windows-official-support-thread.207126) which supported d2x wads since its birth. Without ModMii d2x cios would probably never have existed. Also, XFlak had the original idea to replace the buggy EHCI module of cIOSX rev21 with the  working one from rev19. 
  * *[HackWii](http://www.hackwii.it)* and *[GBAtemp](http://www.gbatemp.net)* communities, for their ideas and support.
  * *Totoro*, for the official d2x logo
  * *ChaN*, for his [FatFs](http://elm-chan.org/fsw/ff/00index_e.html).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 #d2x cIOS
 
-[![d2x-cios logo](http://img403.imageshack.us/img403/585/d2xcioslogo.png)](https://github.com/davebaol/d2x-cios/)
-
+[![d2x-cios logo](https://gbatemp.net/attachments/d2x-logo-jpg.313534)](https://github.com/davebaol/d2x-cios/)
 
 #### DISCLAIMER
-
+**DO NOT USE THIS ON THE WII MINI!**
 ````
 THIS APPLICATION COMES WITH NO WARRANTY AT ALL, NEITHER EXPRESSED NOR IMPLIED.
 NO ONE BUT YOURSELF IS RESPONSIBLE FOR ANY DAMAGE TO YOUR WII CONSOLE BECAUSE OF A IMPROPER USAGE OF THIS SOFTWARE.
 ````
-
-
 
 #### DESCRIPTION
 


### PR DESCRIPTION
Over at https://github.com/davebaol/d2x-cios, xflak added a commit to make the cIOS emunand stuff support UStealth. I should review that and add it to my fork, too - no need to have two diverging forks of the cIOS.

Updated FAT module to add Emunand support for drives hidden by UStealth, source and more info here:
https://gbatemp.net/threads/ciosx-rev21d2x-yet-another-hot-fix.277659/page-163#post-5092147